### PR TITLE
Replace link to deprecated lesson

### DIFF
--- a/docs/learning-course/stage1/1A/sketch-part-modeling.md
+++ b/docs/learning-course/stage1/1A/sketch-part-modeling.md
@@ -9,7 +9,7 @@ Sketches and features are the building blocks you will use to create every 3D mo
 
 1. The [**Introduction to Sketching**](https://learn.onshape.com/courses/fundamentals-sketching "Introduction to Sketching Onshape Learning Course"){:target="_blank"} course runs you through different sketch tools, constraints, and a good sketch workflow.
 
-2. The [**Part Design Using Part Studios**](https://learn.onshape.com/courses/fundamentals-part-design-using-part-studios "Part Design Using Part Studios Onshape Learning Course"){:target="_blank"} course runs you through creating different parts with a variety of features.
+2. The [**Introduction to Part Studios**](https://learn.onshape.com/learn/course/introduction-to-part-studios "Introduction to Part Studios"){:target="_blank"} course runs you through creating different parts with a variety of features.
 
 With a good understanding of both of these, you can create almost any part you want to. The following sections are all about integrating design intent into the process and learning how to design a whole project with multiple pieces.
 


### PR DESCRIPTION
" Part Design Using Part Studios" is now deprecated; I've replaced it with a link to a similar lesson.