### PR TITLE
Fix Table in Layout Sketch

### DIFF
--- a/docs/best-practices/mastersketch-setup.md
+++ b/docs/best-practices/mastersketch-setup.md
@@ -10,12 +10,12 @@ A main layout sketch is a series of sketches that capture the major dimensions o
 <center>
 
 | **Always Include**                                                          | **Sometimes Include**                               | **Never Include**                                           |
-|-----------------------------------------------------------------------------|-----------------------------------------------------|-------------------------------------------------------------|
-| Drivebase dimensions                                                         | Gears                                               | Specific details like the shape of plates                  |
-| End-effector wheel locations based off of prototyping                        | Belts                                               | Gussets                                                     |
-| Field elements and extension limits                                          | Chain                                               | Mounting holes                                              |
-| Mechanism motion paths                                                        | Motor locations                                    |                                                             |
-| Gamepiece path                                                                |                                                     |                                                             |
+|:----------------------------------------------------------------------------|:----------------------------------------------------|:------------------------------------------------------------|
+| Drivebase dimensions                                                        | Gears                                               | Specific details like the shape of plates                   |
+| End-effector wheel locations based off of prototyping                       | Belts                                               | Gussets                                                     |
+| Field elements and extension limits                                         | Chain                                               | Mounting holes                                              |
+| Mechanism motion paths                                                      | Motor locations                                     | &nbsp;                                                      |
+| Gamepiece path                                                              | &nbsp;                                              | &nbsp;                                                      |
 
 
 </center>


### PR DESCRIPTION
![Screenshot 2025-04-14 10 16 01 AM](https://github.com/user-attachments/assets/4e23b2bd-70dd-4abd-af8d-8129e752d58d)

Due to empty cells, the table was not formatting correctly. I added a `&nbsp;` to all empty cells, and it now should work great!