### PR TITLE
Fit to page width

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -125,7 +125,7 @@ a:hover {
 
 /* Slideshow container */
 .slideshow-container {
-  max-width: 1000px;
+  max-width: 100%;
   position: relative;
   margin: auto;
 }
@@ -207,4 +207,8 @@ a:hover {
 @keyframes fade {
   from {opacity: .4}
   to {opacity: 1}
+}
+
+.md-grid {
+  max-width: 100%;
 }


### PR DESCRIPTION
When going through the slideshows, it's particularly hard to see the images / video when they're limited to 1000px, especially on QHD/UHD screens. 