### PR TITLE
Minor typo fix for navigation basic controls

### DIFF
--- a/docs/learning-course/stage1/1A/section1-exercise0.md
+++ b/docs/learning-course/stage1/1A/section1-exercise0.md
@@ -18,7 +18,7 @@ Using the document you copied on the previous page, follow along with the video.
     - The middle mouse button pans the view.
     - The mouse scroll wheel zooms the view.
     - Holding `Ctrl + Right Click` allows you to pan
-    - Holding `Ctrl + Right click` allows you to Rotate flat
+    - Holding `Alt + Right Click` allows you to rotate flat
 
 !!! info "Keep in mind"
 


### PR DESCRIPTION
Ctrl-right click is panning, not rotate flat. It's possibly worth explaining what rotate flat means - in OnShape's documentation, it says:

Alt key animates to nearest 'floor down' view (nearest view without any roll)
Alt + Right Mouse button: horizontal mouse movement about model; vertical mouse movement pitches over model